### PR TITLE
Type name tink.Option is redefined from module tink.MacroApi

### DIFF
--- a/src/tink/MacroApi.hx
+++ b/src/tink/MacroApi.hx
@@ -19,8 +19,6 @@ typedef Unops = tink.macro.Ops.Unary;
 typedef MacroOutcome<D, F> = tink.core.Outcome<D, F>;
 typedef MacroOutcomeTools = tink.OutcomeTools;
 
-typedef Option<T> = haxe.ds.Option<T>;
-
 typedef Member = tink.macro.Member;
 typedef Constructor = tink.macro.Constructor;
 typedef ClassBuilder = tink.macro.ClassBuilder;


### PR DESCRIPTION
Wasn't sure whether to remove it or do a ```typedef MacroOption<T> = ...```, did the less keystrokes fix :sweat_smile: 