### PR TITLE
Fix ClassBuilder's getConstructor() when super class is extern

### DIFF
--- a/src/tink/macro/ClassBuilder.hx
+++ b/src/tink/macro/ClassBuilder.hx
@@ -63,7 +63,9 @@ class ClassBuilder {
           if (cl.constructor != null) {
             try {
               var ctor = cl.constructor.get();
-              var func = Context.getTypedExpr(ctor.expr()).getFunction().sure();
+              var ctorExpr = ctor.expr();
+              if (ctorExpr == null) throw 'Super constructor has no expression';
+              var func = Context.getTypedExpr(ctorExpr).getFunction().sure();
 
               for (arg in func.args) //this is to deal with type parameter substitutions
                 arg.type = null;


### PR DESCRIPTION
Handle super class constructor's expr being `null`, which happens when the super class is an extern with a constructor definition.

In Haxe 3.4.X, this is handled by the compiler by throwing an exception when getting `Context.getTypedExpr(null)`.

In current Haxe 4, however, this breaks the compilation with 'MacroApi.Invalid_expr'. I opened an issue there: https://github.com/HaxeFoundation/haxe/issues/7007 and added a manual throw here.