### PR TITLE
Handle new FunctionKind enum in Haxe 4 AST

### DIFF
--- a/src/tink/macro/Functions.hx
+++ b/src/tink/macro/Functions.hx
@@ -6,7 +6,11 @@ using tink.macro.Exprs;
 
 class Functions {
   static public inline function asExpr(f:Function, ?name, ?pos) 
+  #if (haxe_ver >= 4)
+    return EFunction(name != null ? FNamed(name, false): FAnonymous, f).at(pos);
+  #else
     return EFunction(name, f).at(pos);
+  #end
   
   static public inline function toArg(name:String, ?t, ?opt = false, ?value = null):FunctionArg {
     return {


### PR DESCRIPTION
Handle Haxe 4 breaking change in FunctionKind enum. This change does not work together with change https://github.com/haxetink/tink_template/commit/8e11b996632323a4770b3f554c01213b22abc898
But I think is better to fix it at the root.