### PR TITLE
Deduce common base type from a list of types

### DIFF
--- a/src/tink/macro/Types.hx
+++ b/src/tink/macro/Types.hx
@@ -207,8 +207,19 @@ class Types {
         case TDynamic(v) if(v != null): getPosition(v);
         default: Failure('type "$t" has no position');
       }
-
-
+  
+  static public function deduceCommonType(types:Array<Type>):Outcome<Type, Error> {
+    var exprs = types.map(t ->{
+      var ct = t.toComplex();
+      macro (null:$ct);
+    });
+    
+    return switch (macro $a{exprs}).typeof() {
+      case Success(TInst(_, [v])): Success(v);
+      case Success(_): throw 'unreachable';
+      case Failure(e): Failure(new Error('Unable to deduce common type among $types'));
+    }
+  }
 
   static public function toString(t:ComplexType)
     return new Printer().printComplexType(t);

--- a/src/tink/macro/Types.hx
+++ b/src/tink/macro/Types.hx
@@ -209,9 +209,9 @@ class Types {
       }
   
   static public function deduceCommonType(types:Array<Type>):Outcome<Type, Error> {
-    var exprs = types.map(t ->{
+    var exprs = types.map(function(t) {
       var ct = t.toComplex();
-      macro (null:$ct);
+      return macro (null:$ct);
     });
     
     return switch (macro $a{exprs}).typeof() {

--- a/tests/Types.hx
+++ b/tests/Types.hx
@@ -65,5 +65,19 @@ class Types extends Base {
     assertEquals('String', Context.getType('String').toComplex().toString());
     assertEquals('tink.CoreApi.Noise', Context.getType('tink.CoreApi.Noise').toComplex().toString());
   }
+  
+  function testDeduceCommonType() {
+    assertEquals('StdTypes.Float', tink.macro.Types.deduceCommonType([(macro:Float), (macro:Int)].map(ct -> ct.toType().sure())).sure().toComplex().toString());
+    assertEquals('Types.CommonI1', tink.macro.Types.deduceCommonType([(macro:Types.CommonA), (macro:Types.CommonB), (macro:Types.CommonC)].map(ct -> ct.toType().sure())).sure().toComplex().toString());
+    assertEquals('Types.CommonI2', tink.macro.Types.deduceCommonType([(macro:Types.CommonB), (macro:Types.CommonC)].map(ct -> ct.toType().sure())).sure().toComplex().toString());
+    // assertEquals('Types.CommonI3', tink.macro.Types.deduceCommonType([(macro:Types.CommonC)].map(ct -> ct.toType().sure())).sure().toComplex().toString());
+  }
 }
 #end
+
+interface CommonI1 {}
+interface CommonI2 {}
+interface CommonI3 {}
+class CommonA implements CommonI1 {}
+class CommonB implements CommonI2 implements CommonI1 {}
+class CommonC implements CommonI3 implements CommonI2 implements CommonI1 {}

--- a/tests/Types.hx
+++ b/tests/Types.hx
@@ -67,10 +67,11 @@ class Types extends Base {
   }
   
   function testDeduceCommonType() {
-    assertEquals('StdTypes.Float', tink.macro.Types.deduceCommonType([(macro:Float), (macro:Int)].map(ct -> ct.toType().sure())).sure().toComplex().toString());
-    assertEquals('Types.CommonI1', tink.macro.Types.deduceCommonType([(macro:Types.CommonA), (macro:Types.CommonB), (macro:Types.CommonC)].map(ct -> ct.toType().sure())).sure().toComplex().toString());
-    assertEquals('Types.CommonI2', tink.macro.Types.deduceCommonType([(macro:Types.CommonB), (macro:Types.CommonC)].map(ct -> ct.toType().sure())).sure().toComplex().toString());
-    // assertEquals('Types.CommonI3', tink.macro.Types.deduceCommonType([(macro:Types.CommonC)].map(ct -> ct.toType().sure())).sure().toComplex().toString());
+    function ct2t(ct:ComplexType) return ct.toType().sure();
+    assertEquals('StdTypes.Float', tink.macro.Types.deduceCommonType([(macro:Float), (macro:Int)].map(ct2t)).sure().toComplex().toString());
+    assertEquals('Types.CommonI1', tink.macro.Types.deduceCommonType([(macro:Types.CommonA), (macro:Types.CommonB), (macro:Types.CommonC)].map(ct2t)).sure().toComplex().toString());
+    assertEquals('Types.CommonI2', tink.macro.Types.deduceCommonType([(macro:Types.CommonB), (macro:Types.CommonC)].map(ct2t)).sure().toComplex().toString());
+    // assertEquals('Types.CommonI3', tink.macro.Types.deduceCommonType([(macro:Types.CommonC)].map(ct2t)).sure().toComplex().toString());
   }
 }
 #end


### PR DESCRIPTION
This relies on the compiler to deduce the common types. I am not very sure if the behaviour is clearly specified. For example:

```haxe
interface I1 {}
interface I2 {}
class A implements I2 implements I1 {}
class B implements I2 implements I1 {}
class C implements I1 implements I2 {}
class D implements I1 implements I2 {}

deduceCommonType(A, B); // I2
deduceCommonType(C, D); // I1
```
