### PR TITLE
Fix weird partial module resolution

### DIFF
--- a/src/tink/MacroApi.hx
+++ b/src/tink/MacroApi.hx
@@ -21,7 +21,7 @@ typedef TypeMap<T> = tink.macro.TypeMap<T>;
 
 //TODO: consider adding stuff from haxe.macro.Expr here
 typedef MacroOutcome<D, F> = tink.core.Outcome<D, F>;
-typedef MacroOutcomeTools = tink.OutcomeTools;
+typedef MacroOutcomeTools = tink.core.Outcome.OutcomeTools;
 
 typedef Member = tink.macro.Member;
 typedef Constructor = tink.macro.Constructor;

--- a/src/tink/macro/Exprs.hx
+++ b/src/tink/macro/Exprs.hx
@@ -357,7 +357,7 @@ class Exprs {
           expr = [EVars(locals).at(expr.pos), expr].toMBlock(expr.pos);
         Success(Context.typeof(expr));
       }
-      catch (e:haxe.macro.Error) {
+      catch (e:haxe.macro.Expr.Error) {
         e.pos.makeFailure(e.message);
       }
       catch (e:Dynamic) {


### PR DESCRIPTION
Hi!

tink_macro is using a "trick" with partial resolution at a couple places, which we're removing support for in https://github.com/HaxeFoundation/haxe/pull/11338

For `MacroOutcomeTools`, it was actually pointing to `tink.CoreApi.OutcomeTools`, but I assumed pointing to the actual type rather than the typedef was potentially better here since it's a bit verbose either way?